### PR TITLE
Include traffic in travel time. 

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -8,9 +8,7 @@ config.express = {
   ip: '127.0.0.1'
 };
 
-config.googleMapsAPIKey = {
-  key: process.env.GOOGLE_MAPS_API_KEY || ''
-};
+config.googleMapsAPIKey =  process.env.GOOGLE_MAPS_API_KEY || '';
 
 config.mongodb = {
   port: process.env.MONGODB_PORT || 27017,

--- a/app/reports/reports-component.js
+++ b/app/reports/reports-component.js
@@ -84,7 +84,7 @@ const spotReport = spot => {
 
 
 const spotSecondaryText = spot => {
-  const duration = R.pathOr('loading', [ 'distance','duration' ])(spot);
+  const duration = R.pathOr('loading', [ 'distance','durationInTraffic' ]);
 
   return h('div', {}, [
     h('span', {}, [
@@ -92,7 +92,7 @@ const spotSecondaryText = spot => {
         ' ' + spotSurfRange(spot),
       h('br'),
       h('span', {}, [
-        ' Drive time: ' + duration
+        ' Drive time: ' + duration(spot)
       ])
     ])
   ]);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "flexboxgrid": "^6.3.1",
-    "google-distance": "^1.0.1",
+    "google-distance": "https://github.com/judymou/node-google-distance/tarball/master",
     "jsx-loader": "^0.13.2",
     "material-ui": "^0.16.1",
     "moment": "^2.15.2",


### PR DESCRIPTION
The node module on npm doesn't support the durationInTraffic api. There's a pull request on the project to add it, but it hasn't been merged for months. This brings in a forked version of the module and uses it. 