### PR TITLE
Enable browser geolocation

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -17,7 +17,9 @@ require('./reports/style.scss');
 import store from './store';
 import App from './ReactApp';
 import { fetchSpot } from './reports/actions.js';
-import { fetchDistance } from './travel-time/actions';
+import { fetchDistance, fetchLocation } from './travel-time/actions';
+
+store.dispatch(fetchLocation());
 
 store.dispatch(fetchSpot(4233));//salt creek
 store.dispatch(fetchSpot(53412));//blackies
@@ -27,19 +29,6 @@ store.dispatch(fetchSpot(4217));//seal
 store.dispatch(fetchSpot(4900));//porto
 store.dispatch(fetchSpot(4209));//malibu
 
-
-window.setTimeout(function(){
-  const southCoast = '33.691665,-117.888955';
-  const state = store.getState();
-
-  const dispatcher = spot => {
-    const destination = `${spot.lat},${spot.lon}`;
-
-    store.dispatch(fetchDistance(southCoast, destination, spot.id)) ;
-  };
-
-  R.map(dispatcher, state.reports);
-}, 2000);
 
 ReactDOM.render(
   h(Provider, {

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -5,10 +5,12 @@ import {responsiveStateReducer} from 'redux-responsive';
 
 import { reports, requesting } from './reports/reducer';
 import { tides } from './tides/reducer';
+import { geoLocation } from './travel-time/reducer';
 
 let reducers = combineReducers({
   reports,
   tides,
+  geoLocation,
   browser: responsiveStateReducer,
   requesting
 });

--- a/app/reports/actions.js
+++ b/app/reports/actions.js
@@ -1,9 +1,12 @@
+import { fetchDistance } from '../travel-time/actions';
+
 export function fetchSpot(spotID) {
   return dispatch => {
     dispatch(requestSpot());
     return fetch(`/api/reports/${spotID}`)
       .then(response => response.json())
       .then(json => dispatch(receiveSpot(json)))
+      .then(() => dispatch(fetchDistance(spotID)))
       .catch(err => console.log(err));
   };
 }
@@ -23,3 +26,4 @@ function receiveSpot(json) {
     payload: json
   };
 }
+

--- a/app/store.js
+++ b/app/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { createResponsiveStoreEnhancer } from 'redux-responsive';
-
+import geoMiddleware from 'redux-effects-geolocation';
 
 
 
@@ -13,8 +13,11 @@ import reducers from './reducers';
 let store = createStore(reducers,
   window.devToolsExtension && window.devToolsExtension(),
   compose(
-    createResponsiveStoreEnhancer({performanceMode: true}),
-    applyMiddleware(thunkMiddleware)
+    createResponsiveStoreEnhancer({
+      performanceMode: true
+    }),
+    applyMiddleware(thunkMiddleware,
+      geoMiddleware())
   )
 );
 

--- a/app/travel-time/actions.js
+++ b/app/travel-time/actions.js
@@ -1,12 +1,42 @@
+import R from 'ramda';
 import { getPosition } from 'redux-effects-geolocation';
+import { fetchSpot } from '../reports/actions';
 
-export function fetchDistance(origin, destination, spotId) {
-  return dispatch => {
-    dispatch(requestDistance());
-    return fetch(`/api/distance/${origin}/${destination}`)
-      .then(response => response.json())
-      .then(json => dispatch(receiveDistance(json, spotId)))
-      .catch(err => console.log(err));
+const locationToString = location => {
+  if(location.latitude) {
+    return  `${location.latitude},${location.longitude}`;
+  } else if (location.lat){
+    return  `${location.lat},${location.lon}`;
+  }
+
+  return null;
+};
+
+const fetchAllDistance = (dispatch, getState) => {
+  const reports = getState().reports;
+  const ids = R.compose(R.pluck('id'), R.values);
+
+  const helper = id => {
+    dispatch(fetchDistance(parseInt(id, 10)));
+  };
+
+  R.map(helper, ids(reports));
+};
+
+
+export function fetchDistance(spotID) {
+  return ( dispatch, getState ) => {
+    const origin = locationToString(getState().geoLocation);
+    const destination = locationToString(getState().reports[spotID]);
+
+
+    if(origin != null ) {
+      dispatch(requestDistance());
+      return fetch(`/api/distance/${origin}/${destination}`)
+        .then(response => response.json())
+        .then(json => dispatch(receiveDistance(json, spotID)))
+        .catch(err => console.log(err));
+    };
   };
 }
 
@@ -16,10 +46,11 @@ export const REQUEST_LOCATION = 'REQUEST_LOCATION';
 export const RECEIVE_LOCATION = 'RECEIVE_LOCATION';
 
 export function fetchLocation() {
-  return dispatch => {
+  return (dispatch, getState) => {
     dispatch(requestLocation());
     return dispatch(getPosition())
       .then(json => dispatch(receiveLocation(json)))
+      .then(() => fetchAllDistance(dispatch, getState))
       .catch(err => console.log(err));
   };
 }

--- a/app/travel-time/actions.js
+++ b/app/travel-time/actions.js
@@ -1,3 +1,4 @@
+import { getPosition } from 'redux-effects-geolocation';
 
 export function fetchDistance(origin, destination, spotId) {
   return dispatch => {
@@ -11,7 +12,17 @@ export function fetchDistance(origin, destination, spotId) {
 
 export const REQUEST_DISTANCE = 'REQUEST_DISTANCE';
 export const RECEIVE_DISTANCE = 'RECEIVE_DISTANCE';
+export const REQUEST_LOCATION = 'REQUEST_LOCATION';
+export const RECEIVE_LOCATION = 'RECEIVE_LOCATION';
 
+export function fetchLocation() {
+  return dispatch => {
+    dispatch(requestLocation());
+    return dispatch(getPosition())
+      .then(json => dispatch(receiveLocation(json)))
+      .catch(err => console.log(err));
+  };
+}
 
 export const requestDistance = () => {
   return {
@@ -23,5 +34,18 @@ function receiveDistance(json, spotId) {
   return {
     type: RECEIVE_DISTANCE,
     payload: {json: json, spotId: spotId}
+  };
+}
+
+export const requestLocation = () => {
+  return {
+    type: REQUEST_LOCATION
+  };
+};
+
+function receiveLocation(json) {
+  return {
+    type: RECEIVE_LOCATION,
+    payload: json
   };
 }

--- a/app/travel-time/reducer.js
+++ b/app/travel-time/reducer.js
@@ -1,0 +1,19 @@
+import R from 'ramda';
+
+
+import { RECEIVE_LOCATION, REQUEST_LOCATION } from './actions';
+
+const updateLocation = R.pick(['latitude', 'longitude']);
+
+export const geoLocation = (state = {}, action) => {
+  switch (action.type) {
+    case RECEIVE_LOCATION: {
+
+      return updateLocation(action.payload.coords);
+    }
+    default: {
+      return state;
+    }
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-tap-event-plugin": "^1.0.0",
     "recharts": "^0.15.3",
     "redux": "^3.6.0",
+    "redux-effects-geolocation": "^1.0.2",
     "redux-responsive": "^3.1.5",
     "redux-thunk": "^2.1.0",
     "request": "^2.75.0",


### PR DESCRIPTION
Move `distance` fetching to the travel-time action creators. It's nested, hard to follow logic. It waits till there is both a spot with lat/lon and the user's location. Lot's of async. Another reason to try redux-saga possibly.  Issue #21 